### PR TITLE
Cosmetic/change styles for login and register modals

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import "./App.css";
 import Map from "./components/organisms/map";
-import UserDashboard from "./components/organisms/userDashboard";
 import { UserProvider } from "./contexts/UserContext";
 import OrderList from "./components/Order";
 import Filter from "./components/organisms/Filter";
@@ -18,14 +17,11 @@ function App() {
         <FilterProvider>
           <div className="app-container">
             <div className="app-left">
-
               <Header />
-              <UserDashboard />
               <Filter />
               <Map />
               <MenuResults />
               <Footer />
-
             </div>
             <OrderList />
           </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,23 +14,23 @@ function App() {
 
   return (
     <>
+      <UserProvider>
+        <FilterProvider>
+          <div className="app-container">
+            <div className="app-left">
 
-      <div className="app-container">
-        <div className="app-left">
-          <UserProvider>
-            <FilterProvider>
               <Header />
               <UserDashboard />
               <Filter />
               <Map />
               <MenuResults />
               <Footer />
-            </FilterProvider>
-          </UserProvider>
-        </div>
-        <OrderList />
-      </div>
 
+            </div>
+            <OrderList />
+          </div>
+        </FilterProvider>
+      </UserProvider>
     </>
   );
 }

--- a/src/components/molecules/loginModal.jsx
+++ b/src/components/molecules/loginModal.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useUser } from "../../contexts/UserContext"
+import CloseIcon from '@mui/icons-material/Close';
 
 function LoginModal({ isOpen, handleClose }) {
 
@@ -17,12 +18,12 @@ function LoginModal({ isOpen, handleClose }) {
 
     return (
         (isOpen && <div className='absolute top-0 left-0 flex justify-center items-center h-[100vh] w-full bg-black bg-opacity-25 z-30'>
-            <div className='relative flex justify-center items-center h-1/2 w-4/5 bg-app-yellow'>
+            <div className='relative flex justify-center items-center h-1/2 bg-app-yellow'>
                 <button className='absolute top-0 right-2 text-black text-2xl' onClick={handleClose}>
-                    X
+                    <CloseIcon />
                 </button>
                 <form
-                    className="m-2 p-2"
+                    className="my-2 mx-5 p-2"
                     target=""
                     onSubmit={handleSubmit}
                 >

--- a/src/components/molecules/loginModal.jsx
+++ b/src/components/molecules/loginModal.jsx
@@ -7,7 +7,7 @@ function LoginModal({ isOpen, handleClose }) {
     const [password, setPassword] = useState('');
     const { login } = useUser();
 
-    const inputStyles = 'mt-5 w-full rounded-lg bg-primary-300 px-5 py-3 placeholder-gray-500';
+    const inputStyles = "mt-3 w-full rounded-lg bg-white px-5 py-3 placeholder-gray-500";
 
     const handleSubmit = (e) => {
         e.preventDefault();
@@ -17,23 +17,24 @@ function LoginModal({ isOpen, handleClose }) {
 
     return (
         (isOpen && <div className='absolute top-0 left-0 flex justify-center items-center h-[100vh] w-full bg-black bg-opacity-25 z-30'>
-            <div className='relative flex justify-center items-center h-1/2 w-1/2 bg-slate-600'>
-                <button className='absolute top-0 right-2 text-white text-2xl' onClick={handleClose}>
+            <div className='relative flex justify-center items-center h-1/2 w-4/5 bg-app-yellow'>
+                <button className='absolute top-0 right-2 text-black text-2xl' onClick={handleClose}>
                     X
                 </button>
                 <form
+                    className="m-2 p-2"
                     target=""
                     onSubmit={handleSubmit}
                 >
-                    <label htmlFor="name" className='text-white'>Enter your user name: </label>
+                    <label htmlFor="name" className='text-black my-2'>Enter your user name: </label>
                     <input id="name" className={inputStyles} type="text" placeholder="Name" onChange={(e) => setUsername(e.target.value)} required />
 
-                    <label htmlFor="password" className='text-white'>Create a password: </label>
+                    <label htmlFor="password" className='text-black my-2'>Create a password: </label>
                     <input id="password" className={inputStyles} type="password" placeholder="Password" onChange={(e) => setPassword(e.target.value)} required />
 
                     <button
                         type="submit"
-                        className="mt-5 rounded-lg bg-white px-10 py-3 "
+                        className="min-w-24 h-12 my-4 py-2 text-white font-bold border-b-4 border-blue-500 bg-header-navButton hover:bg-header-navButton-hover rounded-lg"
                     >
                         Submit
                     </button>

--- a/src/components/molecules/loginModal.jsx
+++ b/src/components/molecules/loginModal.jsx
@@ -18,7 +18,7 @@ function LoginModal({ isOpen, handleClose }) {
 
     return (
         (isOpen && <div className='absolute top-0 left-0 flex justify-center items-center h-[100vh] w-full bg-black bg-opacity-25 z-30'>
-            <div className='relative flex justify-center items-center h-1/2 bg-app-yellow'>
+            <div className='relative flex justify-center items-center rounded-lg bg-app-yellow'>
                 <button className='absolute top-0 right-2 text-black text-2xl' onClick={handleClose}>
                     <CloseIcon />
                 </button>

--- a/src/components/molecules/registerModal.jsx
+++ b/src/components/molecules/registerModal.jsx
@@ -7,7 +7,7 @@ function RegisterModal({ isOpen, handleClose }) {
   const { register } = useUser();
 
   const inputStyles =
-    "mt-5 w-full rounded-lg bg-primary-300 px-5 py-3 placeholder-gray-500";
+    "mt-3 w-full rounded-lg bg-white px-5 py-3 placeholder-gray-500";
 
   const handleRegisterSubmit = (e) => {
     e.preventDefault();
@@ -18,15 +18,15 @@ function RegisterModal({ isOpen, handleClose }) {
   return (
     isOpen && (
       <div className="absolute top-0 left-0 flex justify-center items-center h-[100vh] w-full bg-black bg-opacity-25 z-30">
-        <div className="relative flex justify-center items-center h-1/2 w-3/5 bg-slate-600">
+        <div className="relative flex justify-center items-center h-1/2 w-4/5 bg-app-yellow">
           <button
-            className="absolute top-0 right-2 text-white text-2xl"
+            className="absolute top-0 right-2 text-black text-2xl"
             onClick={handleClose}
           >
             X
           </button>
-          <form target="" onSubmit={handleRegisterSubmit}>
-            <label htmlFor="name" className="text-white">
+          <form target="" onSubmit={handleRegisterSubmit} className="m-2 p-2">
+            <label htmlFor="name" className="text-black my-2">
               Create a username:{" "}
             </label>
             <input
@@ -38,7 +38,7 @@ function RegisterModal({ isOpen, handleClose }) {
               required
             />
 
-            <label htmlFor="password" className="text-white">
+            <label htmlFor="password" className="text-black my-5">
               Create a password:{" "}
             </label>
             <input
@@ -52,7 +52,7 @@ function RegisterModal({ isOpen, handleClose }) {
 
             <button
               type="submit"
-              className="mt-5 rounded-lg bg-white px-10 py-3 "
+              className="min-w-24 h-12 my-4 py-2 text-white font-bold border-b-4 border-blue-500 bg-header-navButton hover:bg-header-navButton-hover rounded-lg"
             >
               Submit
             </button>

--- a/src/components/molecules/registerModal.jsx
+++ b/src/components/molecules/registerModal.jsx
@@ -19,14 +19,14 @@ function RegisterModal({ isOpen, handleClose }) {
   return (
     isOpen && (
       <div className="absolute top-0 left-0 flex justify-center items-center h-[100vh] w-full bg-black bg-opacity-25 z-30">
-        <div className="relative flex justify-center items-center h-1/2 bg-app-yellow">
+        <div className="relative flex justify-center items-center rounded-lg bg-app-yellow">
           <button
             className="absolute top-0 right-2 text-black text-2xl"
             onClick={handleClose}
           >
             <CloseIcon />
           </button>
-          <form target="" onSubmit={handleRegisterSubmit} className="my-2 mx-5 p-2">
+          <form target="" onSubmit={handleRegisterSubmit} className="my-8 mx-5 p-2">
             <label htmlFor="name" className="text-black my-2">
               Create a username:{" "}
             </label>

--- a/src/components/molecules/registerModal.jsx
+++ b/src/components/molecules/registerModal.jsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useUser } from "../../contexts/UserContext";
+import CloseIcon from '@mui/icons-material/Close';
 
 function RegisterModal({ isOpen, handleClose }) {
   const [username, setUsername] = useState("");
@@ -18,14 +19,14 @@ function RegisterModal({ isOpen, handleClose }) {
   return (
     isOpen && (
       <div className="absolute top-0 left-0 flex justify-center items-center h-[100vh] w-full bg-black bg-opacity-25 z-30">
-        <div className="relative flex justify-center items-center h-1/2 w-4/5 bg-app-yellow">
+        <div className="relative flex justify-center items-center h-1/2 bg-app-yellow">
           <button
             className="absolute top-0 right-2 text-black text-2xl"
             onClick={handleClose}
           >
-            X
+            <CloseIcon />
           </button>
-          <form target="" onSubmit={handleRegisterSubmit} className="m-2 p-2">
+          <form target="" onSubmit={handleRegisterSubmit} className="my-2 mx-5 p-2">
             <label htmlFor="name" className="text-black my-2">
               Create a username:{" "}
             </label>

--- a/src/components/organisms/map.jsx
+++ b/src/components/organisms/map.jsx
@@ -1,14 +1,7 @@
 import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet'
-import useSWR from 'swr';
 import { useLocation } from '@/contexts/FilterContext';
 
-const fetcher = async (...args) => await fetch(...args).then(async response => await response.json());
-
 const map = (props) => {
-
-    const url = "https://menus-api.vercel.app/";
-    const { data, error } = useSWR(url, { fetcher });
-    const restaurantsData = data && !error ? data["bbqs"].slice(0, 20) : [];
 
     const { filteredData } = useLocation();
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Main changes:
Cosmetic changes for Login and Register Modals including
- buttons changed to match navBar buttons
- added Material Icon close buttons
- color scheme changed to match app
- margin and padding changes, and various minor tweaks

Other changes:
- Got rid of user dashboard on the home screen, now that it is displayed in the Order menu
- Cleaned up the map component, got rid of hard coded data
- moved UserProvider and FilterProvider tags to encapsulate all other tags on App.tsx. This is needed for context to work correctly


## Related Tickets & Documents

- Closes #66
- Closes #67 

## QA Instructions, Screenshots, Recordings

New modals should look like this:

![image](https://github.com/user-attachments/assets/8f76dc81-b5d1-4bac-a2c1-ed651cda872d)
